### PR TITLE
chore: release v0.1.0

### DIFF
--- a/fromenv-derive/CHANGELOG.md
+++ b/fromenv-derive/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ollyswanson/fromenv/releases/tag/fromenv-derive-v0.1.0) - 2025-08-10
+
+### Added
+
+- Set doc comments on setter methods
+- Add "path" to error reporting
+- Improve diagnostics from unrecognized fields
+- requirements
+
+### Fixed
+
+- Update pub struct error message
+
+### Other
+
+- Add missing items to manifest
+- Use cargo-rdme to interpolate rustdocs
+- Add licenses
+- Document usage + motivation
+- Global rename to `FromEnv`

--- a/fromenv/CHANGELOG.md
+++ b/fromenv/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ollyswanson/fromenv/releases/tag/fromenv-v0.1.0) - 2025-08-10
+
+### Added
+
+- Adjust error message based on error count
+- Add "path" to error reporting
+- Improve diagnostics from unrecognized fields
+- requirements
+
+### Fixed
+
+- Update pub struct error message
+
+### Other
+
+- Specify version of fromenv-derive
+- Add missing items to manifest
+- Use cargo-rdme to interpolate rustdocs
+- Add licenses
+- Remove `FromEnvError` from public API
+- Document usage + motivation
+- Include Send + Sync bounds on BoxError
+- Rename `ParserResult` to `ParseResult`
+- Test error messages + rename ui tests
+- Add more trybuild tests
+- Scaffold trybuild tests
+- Global rename to `FromEnv`


### PR DESCRIPTION



## 🤖 New release

* `fromenv-derive`: 0.1.0
* `fromenv`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `fromenv-derive`

<blockquote>

## [0.1.0](https://github.com/ollyswanson/fromenv/releases/tag/fromenv-derive-v0.1.0) - 2025-08-10

### Added

- Set doc comments on setter methods
- Add "path" to error reporting
- Improve diagnostics from unrecognized fields
- requirements

### Fixed

- Update pub struct error message

### Other

- Add missing items to manifest
- Use cargo-rdme to interpolate rustdocs
- Add licenses
- Document usage + motivation
- Global rename to `FromEnv`
</blockquote>

## `fromenv`

<blockquote>

## [0.1.0](https://github.com/ollyswanson/fromenv/releases/tag/fromenv-v0.1.0) - 2025-08-10

### Added

- Adjust error message based on error count
- Add "path" to error reporting
- Improve diagnostics from unrecognized fields
- requirements

### Fixed

- Update pub struct error message

### Other

- Specify version of fromenv-derive
- Add missing items to manifest
- Use cargo-rdme to interpolate rustdocs
- Add licenses
- Remove `FromEnvError` from public API
- Document usage + motivation
- Include Send + Sync bounds on BoxError
- Rename `ParserResult` to `ParseResult`
- Test error messages + rename ui tests
- Add more trybuild tests
- Scaffold trybuild tests
- Global rename to `FromEnv`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).