### PR TITLE
fix: clippy `same-name-method` lint

### DIFF
--- a/fromenv-derive/CHANGELOG.md
+++ b/fromenv-derive/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [`same_name_method`](https://rust-lang.github.io/rust-clippy/master/index.html#same_name_method) clippy lint
+
 ## [0.1.0](https://github.com/ollyswanson/fromenv/releases/tag/fromenv-derive-v0.1.0) - 2025-08-10
 
 ### Added

--- a/fromenv-derive/src/lib.rs
+++ b/fromenv-derive/src/lib.rs
@@ -125,10 +125,12 @@ impl FromEnvReceiver {
 
         quote! {
             impl #struct_name {
+                #[allow(clippy::same_name_method)]
                 pub fn from_env() -> #builder_name {
                     <Self as #private_path::FromEnv>::from_env()
                 }
 
+                #[allow(clippy::same_name_method)]
                 pub fn requirements() -> String {
                     let mut requirements = ::std::string::String::new();
                     <Self as #private_path::FromEnv>::requirements(&mut requirements);
@@ -457,6 +459,7 @@ impl FromEnvReceiver {
             impl #builder_name {
                 #(#setters)*
 
+                #[allow(clippy::same_name_method)]
                 pub fn finalize(self) -> Result<<Self as #private_path::FromEnvBuilder>::Target, #private_path::FromEnvErrors> {
                     #private_path::FromEnvBuilder::finalize(self)
                 }

--- a/fromenv/CHANGELOG.md
+++ b/fromenv/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [`same_name_method`](https://rust-lang.github.io/rust-clippy/master/index.html#same_name_method) clippy lint
+
 ## [0.1.0](https://github.com/ollyswanson/fromenv/releases/tag/fromenv-v0.1.0) - 2025-08-10
 
 ### Added


### PR DESCRIPTION
Fixes [`same-name-method`](https://rust-lang.github.io/rust-clippy/master/index.html#same_name_method) clippy lint

I can prepare everything for release 0.1.1 if needed